### PR TITLE
docs: add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contribuindo
+
+Obrigado por considerar contribuir com um projeto NPA Tecnologia.
+
+## Workflow
+
+1. Fork do repositório
+2. Criar branch descritiva (`feat/nome-da-feature`, `fix/descricao-do-bug`)
+3. Commits pequenos e atômicos seguindo Conventional Commits
+4. Testes passando localmente (`pnpm test`, `pnpm typecheck`, `pnpm lint`)
+5. Abrir PR contra `main` usando o template de PR
+6. Aguardar review — respondemos em até 48h úteis
+
+## Padrões
+
+- TypeScript strict sempre que disponível
+- Funções pequenas (<50 linhas) e arquivos focados (<800 linhas)
+- Imutabilidade como padrão — evitar mutação in-place
+- Segurança desde o primeiro commit — nunca hardcode de secrets
+
+## Contato
+
+Dúvidas: nathan@npatecnologia.com.br


### PR DESCRIPTION
Adiciona guia de contribuição padrão para projetos NPA. Inclui workflow, padrões de código e contato.