### PR TITLE
chore: expand .gitignore coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,14 +14,20 @@ build/
 .env
 .env.local
 .env.*.local
+.env.production
 
 # Vercel
 .vercel
+
+# Turborepo
+.turbo/
 
 # Logs
 *.log
 npm-debug.log*
 pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
 # IDE
 .vscode/
@@ -32,11 +38,22 @@ pnpm-debug.log*
 # OS
 .DS_Store
 Thumbs.db
+desktop.ini
+$RECYCLE.BIN/
 
 # Testing
 coverage/
 .nyc_output/
+playwright-report/
+test-results/
 
 # TypeScript
 *.tsbuildinfo
 next-env.d.ts
+
+# Sentry
+.sentryclirc
+
+# Miscellaneous
+.cache/
+tmp/


### PR DESCRIPTION
Adiciona padrões comumente esquecidos: Turborepo cache, Sentry CLI config, Playwright reports, Yarn logs, lixo do Windows, .env.production. Preventivo — evita commits acidentais em projetos novos.