### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Padroniza formatação cross-editor: UTF-8, LF, 2 espaços, newline no EOF, trim trailing. Exceção de trim pra Markdown (preserva quebra dupla).