### PR TITLE
chore: add .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,20 @@
+# Build artifacts
+.next
+out
+dist
+build
+coverage
+
+# Dependencies
+node_modules
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+
+# Generated
+*.tsbuildinfo
+next-env.d.ts
+.turbo
+
+# Vendored
+public


### PR DESCRIPTION
Evita rodar Prettier em lockfiles, build output e pastas geradas. Acelera format em CI e pre-commit hooks.