### PR TITLE
ci: add Dependabot for npm + actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+      include: scope
+    labels:
+      - dependencies
+      - ci


### PR DESCRIPTION
Atualiza dependências npm semanalmente (segunda 8am BRT, max 5 PRs abertos) e GitHub Actions mensalmente. Labels automáticas, mensagens padronizadas.