### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Todos os arquivos têm como owner default o fundador
+*                          @NPATecnologia
+
+# Infra / CI
+/.github/                  @NPATecnologia
+/.github/workflows/        @NPATecnologia
+
+# Config crítica
+/LICENSE                   @NPATecnologia
+/SECURITY.md               @NPATecnologia


### PR DESCRIPTION
Define ownership automático de paths. CI, workflows, LICENSE e SECURITY precisam de review explícito do owner em PRs.