### PR TITLE
chore: add VSCode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit"
+  },
+  "editor.tabSize": 2,
+  "editor.rulers": [100],
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "typescript.preferences.importModuleSpecifier": "relative",
+  "typescript.updateImportsOnFileMove.enabled": "always",
+  "tailwindCSS.experimental.classRegex": [
+    ["cva\(([^)]*)\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+    ["cx\(([^)]*)\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+  ]
+}


### PR DESCRIPTION
Format on save com Prettier, ESLint fix on save, organize imports auto, ruler em 100 cols, LF, Tailwind IntelliSense reconhece cva/cx helpers.