### PR TITLE
chore: add commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,27 @@
+/** @type {import('@commitlint/types').UserConfig} */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'refactor',
+        'docs',
+        'style',
+        'test',
+        'chore',
+        'perf',
+        'ci',
+        'build',
+        'revert',
+      ],
+    ],
+    'subject-case': [2, 'never', ['upper-case', 'pascal-case']],
+    'header-max-length': [2, 'always', 100],
+    'body-leading-blank': [1, 'always'],
+    'footer-leading-blank': [1, 'always'],
+  },
+};


### PR DESCRIPTION
Valida mensagens de commit contra Conventional Commits. Permite types: feat, fix, refactor, docs, style, test, chore, perf, ci, build, revert. Header max 100 chars, blank lines entre header/body/footer.